### PR TITLE
Update deprecated urwid.util usage

### DIFF
--- a/urwid_readline/readline_edit.py
+++ b/urwid_readline/readline_edit.py
@@ -6,7 +6,7 @@ import urwid
 
 
 def _is_valid_key(char):
-    return urwid.util.is_wide_char(char, 0) or (
+    return urwid.is_wide_char(char, 0) or (
         len(char) == 1 and ord(char) >= 32
     )
 


### PR DESCRIPTION
In urwid 2.6.0, using some functions from the `urwid.util` package was deprecated in favor of using them directly from `urwid`. Here `urwid.util.is_wide_char` is changed to `urwid.is_wide_char`. `is_wide_char` has been available from the `urwid` namespace for many years, so there should be no backwards compatibility isssues.

For details about the urwid change, see https://github.com/urwid/urwid/pull/803.